### PR TITLE
Commented out an unused counter variable.

### DIFF
--- a/mica_ppm.cpp
+++ b/mica_ppm.cpp
@@ -532,7 +532,7 @@ void register_condBr(ADDRINT ins_addr){
 	indices_condBr[numStatCondBranchInst++] = ins_addr;
 }
 
-static int _count  = 0;
+// static int _count  = 0;
 VOID instrument_ppm_cond_br(INS ins){
     UINT32 index = index_condBr(INS_Address(ins));
 	if(index < 1){


### PR DESCRIPTION
This allows MICA to be used with PIN 3.7, on Ubuntu 19.04 with the latest GCC. 

Tested and working locally. 