### PR TITLE
Update mica.h for fix ppm mismatch

### DIFF
--- a/mica.h
+++ b/mica.h
@@ -63,7 +63,7 @@ extern int append_pid;
 /* PPM */
 #define MAX_HIST_LENGTH 12
 #define NUM_HIST_LENGTHS 3
-const UINT32 history_lengths[NUM_HIST_LENGTHS] = {12,8,4};
+const UINT32 history_lengths[NUM_HIST_LENGTHS] = {4,8,12};
 
 /* REG */
 #define MAX_NUM_REGS 4096


### PR DESCRIPTION
Fixed confusion in PPM output. History length GAg,PAg,GAs,PAs value for 12 bits was printed with a header of 4 bits and vice versa. This change allows not to change legends in the output table, will allow to continue using them with scripts processing.